### PR TITLE
Resolve #14: Roll buttons not working in popup chat

### DIFF
--- a/modules/utils/animations.mjs
+++ b/modules/utils/animations.mjs
@@ -24,24 +24,22 @@
  *                                 once the CSS transition has ended or timed out.
  */
 export default function transitionClass(element, { remove = [], add = [] }, timeout = 1000) {
-  return new Promise((resolve) => {
-    let eventFired = false;
+  const { promise, resolve } = Promise.withResolvers();
+  let eventFired = false;
 
-    function handleTransitionEnd() {
-      eventFired = true;
-      resolve(element);
-    }
+  const handlePromise = () => {
+    if (eventFired) return;
+    eventFired = true;
+    resolve(element);
+  };
 
-    element.addEventListener("transitionend", handleTransitionEnd, {
-      once: true,
-    });
+  element.addEventListener("transitionend", handlePromise, { once: true });
 
-    // Fallback timeout to ensure promise always resolves
-    setTimeout(() => {
-      if (!eventFired) resolve(element);
-    }, timeout);
+  // Fallback timeout to ensure promise always resolves
+  setTimeout(handlePromise, timeout);
 
-    element.classList.remove(...remove);
-    element.classList.add(...add);
-  });
+  element.classList.remove(...remove);
+  element.classList.add(...add);
+
+  return promise;
 }


### PR DESCRIPTION
I found the underlying issue in the transitionClass function. Here we were only resolving the function's `Promise` when the `transitionend` listener was fired. However, if the chat log itself was not visible, this listener is never called, and thus the promise is never resolved. This blocks an update to the underlying document and leaves the chat message in a half-updated state.

To solve, I added a timeout which resolved the promise after 1 second, if it isn't already resolved via the `transitionend` listener. This way we resolve the promise and the document gets updated regardless of whether the transition actually happens.

To test:
1. make a roll from a character sheet while the chat log (right sidebar) is closed.
2.  Quickly, in the chat message that popped up, click "Narrativium". 
3. Open the chatlog and confirm that the update occurred (on the main branch, this would not be true; see the video in the linked issue)

Closes #14 