### PR TITLE
Fix width of `nav.tabs` on very wide sheets

### DIFF
--- a/styles/doc-sheets/_base-sheet.scss
+++ b/styles/doc-sheets/_base-sheet.scss
@@ -186,6 +186,11 @@
     line-height: 1.75;
     gap: 2rem;
 
+    width: 100%;
+    max-width: 540px;
+    min-width: 300px;
+    align-self: center;
+
     color: getVar(color, title);
 
     margin: 0.5rem 0 0.25rem 0;
@@ -200,10 +205,10 @@
 
       z-index: 1;
       position: absolute;
-      bottom: -25px;
+      bottom: -35px;
 
       width: 100%;
-      height: 100%;
+      height: 45px;
 
       background-image: url(#{$assetsPrefix}/sheet/banner-decoration-01.webp);
       background-size: 100%;

--- a/system.json
+++ b/system.json
@@ -5,7 +5,7 @@
   "version": "dev",
   "license": "Apache License, Version 2.0",
   "compatibility": {
-    "minimum": "13.338",
+    "minimum": "13.351",
     "verified": "13"
   },
   "authors": [


### PR DESCRIPTION
<img width="877" height="772" alt="image" src="https://github.com/user-attachments/assets/e2cd00cd-5eca-44c2-9589-c151b057aa16" />

Also bumps `system.json`'s compatibility