### PR TITLE
Upgrade system for v14 compatibility

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -2,11 +2,13 @@
   "DISCWORLD": {
     "character": {
       "luck": "Luck",
-      "pronouns": "Pronouns",
 
       "FIELDS": {
         "description": {
           "label": "Description"
+        },
+        "pronouns": {
+          "placeholder": "Pronouns"
         }
       }
     },
@@ -90,6 +92,11 @@
           "label": "Type"
         }
       }
+    },
+
+    "PACKS": {
+      "PREGENS": "Pre-Generated Characters",
+      "QUICKSTART": "Quickstart"
     }
   },
 

--- a/modules/chat/chat-message.mjs
+++ b/modules/chat/chat-message.mjs
@@ -7,10 +7,10 @@ import transitionClass from "../utils/animations.mjs";
  * Discworld chat message class.
  * @extends ChatMessage
  */
-export default class DiscworldMessage extends ChatMessage {
+export default class DiscworldMessage extends foundry.documents.ChatMessage {
   /**
-   *  The message element from the chat log (null if message isn't rendered).
-   *  @type {HTMLLIElement | null}
+   * The message element from the chat log (null if message isn't rendered).
+   * @type {HTMLLIElement | null}
    */
   get element() {
     const chatLog = document.getElementById("chat");
@@ -22,7 +22,7 @@ export default class DiscworldMessage extends ChatMessage {
   /**
    * The main roll of the chat message (null if message is not a Roll type).
    * @type {DWTraitRoll}
-   * @throws {Error}
+   * @throws    If the message does not contain a roll.
    */
   get mainRoll() {
     const roll = this.rolls[0];
@@ -57,9 +57,8 @@ export default class DiscworldMessage extends ChatMessage {
   /* -------------------------------------------------- */
 
   /**
-   *  The second (reroll) Narrativium roll of the chat message
-   *  (null if Narrativium has not been re-rolled).
-   *  @type {DWNarrativiumRoll | null}
+   * The second (reroll) Narrativium roll of the chat message (null if Narrativium has not been re-rolled).
+   * @type {DWNarrativiumRoll | null}
    */
   get gmReroll() {
     return (
@@ -71,20 +70,13 @@ export default class DiscworldMessage extends ChatMessage {
 
   /* -------------------------------------------------- */
 
-  /**
-   * Intercept creation of chat message to inject the roll template,
-   * if applicable.
-   *
-   * @inheritdoc
-   * @param {object} data - The chat message data.
-   * @param {Partial<Omit<DatabaseCreateOperation, "data">>} [operation={}]  Parameters of the creation operation
-   * @returns {Promise<DiscworldMessage>}
-   */
+  /** @inheritdoc */
   static async create(data, operation = {}) {
     const message = new DiscworldMessage(data);
     if (!message.isRoll || !(message.mainRoll instanceof DWTraitRoll))
       return super.create(message, operation);
 
+    // Intercept creation of chat message to inject the roll template, if applicable.
     const chatData = await message._prepareContext();
     const content = await foundry.applications.handlebars.renderTemplate(
       message.mainRoll.template,
@@ -98,11 +90,14 @@ export default class DiscworldMessage extends ChatMessage {
   /**
    * Add a roll to the chat message. Animate the 3d dice (if present),
    * animate the chat message, finally, update the database.
-   *
-   * @param {DWHelpRoll | DWNarrativiumRoll} roll - The roll to add.
+   * @param {DWHelpRoll | DWNarrativiumRoll} roll   The roll to add.
    * @returns {Promise<DiscworldMessage>}
    */
   async addRoll(roll) {
+    if (!roll._evaluated) {
+      throw new Error("Cannot add an unevaluated roll");
+    }
+
     // Creating an update to `ChatMessage#rolls` (as we do in this function) triggers a DiceSoNice animation.
     // However, the dice animation and the chat animation must happen before the database update (which occurs last).
     // So, we manually trigger it first, using DiceSoNice's API and *then* hide the dice from DSN, so it doesn't get
@@ -118,11 +113,9 @@ export default class DiscworldMessage extends ChatMessage {
         chatDataOverrides.helpRoll = roll;
         break;
 
-      case roll instanceof DWNarrativiumRoll: {
-        const rollKey = roll.options.reroll ? "gmReroll" : "gmRoll";
-        chatDataOverrides[rollKey] = roll;
+      case roll instanceof DWNarrativiumRoll:
+        chatDataOverrides[roll.options.reroll ? "gmReroll" : "gmRoll"] = roll;
         break;
-      }
 
       default:
         break;
@@ -173,14 +166,15 @@ export default class DiscworldMessage extends ChatMessage {
    * @typedef {RollContext & {css: CssData}} MessageContext
    */
 
+  /* -------------------------------------------------- */
+
   /**
    * Prepare the context for rendering a chat message by merging roll data
    * with any provided overrides. Additionally, prepare CSS data for styling
    * the message based on the roll results.
-   *
-   * @param {RollContext} [dataOverrides={}] - Roll data for a Roll which has not yet been added
-   *                                      to `ChatMessage#rolls`,but will be on next render.
-   * @returns {Promise<MessageContext>} - The prepared context including Roll and CSS data.
+   * @param {RollContext} [dataOverrides={}]    Roll data for a Roll which has not yet been added
+   *                                            to `ChatMessage#rolls`,but will be on next render.
+   * @returns {Promise<MessageContext>}         The prepared context including Roll and CSS data.
    */
   async _prepareContext(dataOverrides = {}) {
     const { mainRoll, helpRoll, gmRoll, gmReroll } = this;
@@ -190,8 +184,8 @@ export default class DiscworldMessage extends ChatMessage {
       gmRoll,
       gmReroll,
     };
-    const context = foundry.utils.mergeObject(rollData, dataOverrides);
 
+    const context = Object.assign(rollData, dataOverrides);
     context.css = this._prepareCssData(context);
 
     return context;
@@ -201,17 +195,16 @@ export default class DiscworldMessage extends ChatMessage {
 
   /**
    * Prepare CSS data for styling a chat message based on the roll results.
-   *
-   * @param {RollContext} [context = {}] - The context to evaluate.
-   * @returns {CssData} - The prepared CSS data.
+   * @param {RollContext} [context = {}]    The context to evaluate.
+   * @returns {CssData}                     The prepared CSS data.
    */
   _prepareCssData(context = {}) {
     /**
      * Get the class name for a given section of results.
      *
-     * @param {UserRoles} userRole - The user role to get the class for.
-     * @returns {OutcomeClassOptions} - The class name for the winner,
-     *                                    or null if the role hasn't been evaluated.
+     * @param {UserRoles} userRole      The user role to get the class for.
+     * @returns {OutcomeClassOptions}   The class name for the winner,
+     *                                  or null if the role hasn't been evaluated.
      */
     const outcomeClass = (userRole) => {
       const { status, winner } = this.outcome(context);
@@ -246,15 +239,9 @@ export default class DiscworldMessage extends ChatMessage {
   /* -------------------------------------------------- */
 
   /**
-   * Evaluate the outcome of a test based on whether the
-   * player or GM/Narrativium won.
-   *
-   * @param {RollContext} [context] - The context to evaluate.
-   * @returns {{
-   *             status: "tie" | "win" | null,
-   *             winner: UserRoles | null
-   *          }}
-   *          - An object with `status` and `winner` properties.
+   * Evaluate the outcome of a test based on whether the player or GM/Narrativium won.
+   * @param {RollContext} [context]   The context to evaluate.
+   * @returns {{ status: "tie" | "win" | null, winner: UserRoles | null }}
    */
   outcome({
     mainRoll = this.mainRoll,
@@ -281,13 +268,14 @@ export default class DiscworldMessage extends ChatMessage {
     };
   }
 
-  /* ---------------- Animation Helpers --------------- */
+  /* -------------------------------------------------- */
+  /*   Animation Helpers                                */
+  /* -------------------------------------------------- */
 
   /**
    * Delegates chat animation of a roll result, based on the type of roll.
-   *
-   * @param {DWHelpRoll | DWNarrativiumRoll} roll - The roll to animate.
-   * @returns {Promise<void>} gagadd
+   * @param {DWHelpRoll | DWNarrativiumRoll} roll   The roll to animate.
+   * @returns {Promise<void>}
    */
   async animateRoll(roll) {
     if (roll instanceof DWHelpRoll) return this.animateHelp(roll);
@@ -298,8 +286,7 @@ export default class DiscworldMessage extends ChatMessage {
 
   /**
    * Handles animation of a Help roll.
-   *
-   * @param {DWHelpRoll} roll - The roll to animate.
+   * @param {DWHelpRoll} roll   The roll to animate.
    * @returns {Promise<void>}
    */
   async animateHelp(roll) {
@@ -311,8 +298,7 @@ export default class DiscworldMessage extends ChatMessage {
 
   /**
    * Handles animation of a Narrativium roll, whether it's regular or reroll.
-   *
-   * @param {DWNarrativiumRoll} roll - The roll to animate.
+   * @param {DWNarrativiumRoll} roll    The roll to animate.
    * @returns {Promise<void>}
    */
   async animateNarrativium(roll) {
@@ -329,9 +315,9 @@ export default class DiscworldMessage extends ChatMessage {
 
   /**
    * Slide the dice icon of a given class name to over from the center of its container.
-   *
-   * @param {"playerResult" | "gmResult"} resultClass - The class name of the roll whose icon should be moved.
-   * @returns {Promise<HTMLLIElement>} Promise that resolves with the element once the transition has ended.
+   * @param {"playerResult" | "gmResult"} resultClass   The class name of the roll whose icon should be moved.
+   * @returns {Promise<HTMLLIElement>}                  A promise that resolves to the transitioning element
+   *                                                    once the transition has ended.
    */
   async slideDiceIcon(resultClass) {
     const dieListItem = this.element.querySelector(`li.${resultClass}`);
@@ -345,11 +331,11 @@ export default class DiscworldMessage extends ChatMessage {
 
   /**
    * Fade in the dice icon of a given class name.
-   *
-   * @param {"helpResult" | "gmRerollResult"} resultClass - The class name of the roll whose icon should be faded.
-   * @param {number} rollResult - The new result to display.
-   * @param {"d4" | "d6" | "d10" | "d12" | null} [rollTerm=null] - An additional class name to apply to the dice icon.
-   * @returns {Promise<HTMLLIElement>} Promise that resolves with the element once the transition has ended.
+   * @param {"helpResult" | "gmRerollResult"} resultClass           The class name of the roll whose icon should be faded.
+   * @param {number} rollResult                                     The new result to display.
+   * @param {"d4" | "d6" | "d10" | "d12" | null} [rollTerm=null]    An additional class name to apply to the dice icon.
+   * @returns {Promise<HTMLLIElement>}                              A promise that resolves to the transitioning element
+   *                                                                once the transition has ended.
    */
   async fadeDiceIcon(resultClass, rollResult, rollTerm = null) {
     const dieListItem = this.element.querySelector(`li.${resultClass}`);
@@ -362,12 +348,11 @@ export default class DiscworldMessage extends ChatMessage {
   /* -------------------------------------------------- */
 
   /**
-   * Fades a text element out, updates its content with a new roll result,
-   * and then fades it back in.
-   *
-   * @param {"gmResult"} resultClass - The class name of the result element whose text should be updated.
-   * @param {number} rollResult - The new result to display within the text element.
-   * @returns {Promise<HTMLSpanElement>} Promise that resolves with the element once the transition has ended.
+   * Fades a text element out, updates its content with a new roll result, and then fades it back in.
+   * @param {"gmResult"} resultClass        The class name of the result element whose text should be updated.
+   * @param {number} rollResult             The new result to display within the text element.
+   * @returns {Promise<HTMLSpanElement>}    A promise that resolves to the transitioning element
+   *                                        once the transition has ended.
    */
   async fadeTextInOut(resultClass, rollResult) {
     const resultSpan = this.element.querySelector(`li.${resultClass} span`);

--- a/modules/chat/chat.mjs
+++ b/modules/chat/chat.mjs
@@ -15,58 +15,22 @@ export default class DiscworldChatLog extends foundry.applications.sidebar.tabs.
   /* -------------------------------------------------- */
 
   /**
-   * Add custom button listeners to the chat log.
-   *
-   * @inheritdoc
-   * @param {jQuery} html - The jQuery object that represents the chat log.
-   * @returns {void}
-   */
-  activateListeners(html) {
-    // TODO: Remove once v12 support is dropped.
-    super.activateListeners(html);
-
-    const [chatLog] = html;
-    chatLog.addEventListener("click", (event) => {
-      // Delegate event handling based on the closest button clicked
-      switch (true) {
-        // Handle clicks on "narrativium" button
-        case !!event.target.closest("button.narrativium"):
-          DiscworldChatLog.#onRollNarrativium.call(this, event);
-          break;
-
-        // Handle clicks on "help" button
-        case !!event.target.closest("button.help"):
-          DiscworldChatLog.#onHelp.call(this, event);
-          break;
-
-        // Otherwise, do nada.
-        default:
-          break;
-      }
-    });
-  }
-
-  /* -------------------------------------------------- */
-
-  /**
    * Respond to a user clicking the "Help" button by:
    *   1. Opening the user's character sheet in "help mode".
    *   2. Waiting for a Trait to be clicked.
    *   3. Creating the Trait help roll.
-   *
-   * @param {Event} event - The originating click event.
-   * @param {HTMLElement} target - The target element of the event.
-   * @returns {void}
+   * @param {PointerEvent} event    The originating click event.
+   * @param {HTMLElement} target    The element that defined the [data-action].
    */
   static async #onHelp(event, target) {
     const { message } = DiscworldChatLog.getClickedMessageData(event, target);
     if (message.helpRoll) return;
 
+    if (!canvas.ready) return;
+
     const controlledTokens = canvas.tokens.controlled;
     if (controlledTokens.length > 1) {
-      ui.notifications.warn("DISCWORLD.chat.warning.singleTokenSelect", {
-        localize: true,
-      });
+      ui.notifications.warn("DISCWORLD.chat.warning.singleTokenSelect", { localize: true });
       return;
     }
 
@@ -75,20 +39,13 @@ export default class DiscworldChatLog extends foundry.applications.sidebar.tabs.
     const actor = token?.actor ?? game.user.character;
 
     if (!actor) {
-      ui.notifications.warn("DISCWORLD.chat.warning.actorNotFound", {
-        localize: true,
-      });
+      ui.notifications.warn("DISCWORLD.chat.warning.actorNotFound", { localize: true });
       return;
     }
 
     // Warn and prevent roll if character has no luck remaining.
     if (!actor.system.luck.value) {
-      // TODO: This can be cleaned up in v13.
-      ui.notifications.warn(
-        game.i18n.format("DISCWORLD.chat.warning.noLuck", {
-          actorName: actor.name,
-        }),
-      );
+      ui.notifications.warn("DISCWORLD.chat.warning.noLuck", { format: { actorName: actor.name } });
       return;
     }
 
@@ -101,19 +58,14 @@ export default class DiscworldChatLog extends foundry.applications.sidebar.tabs.
   /**
    * Respond to the GM clicking the "Narrativium" button
    * by creating a Narrativium (d8) Roll.
-   *
-   * @param {Event} event - The originating click event.
-   * @param {HTMLElement} target - The target element of the event.
-   * @returns {void}
+   * @param {PointerEvent} event    The originating click event.
+   * @param {HTMLElement} target    The element that defined the [data-action].
    */
   static #onRollNarrativium(event, target) {
     if (!game.user.isGM) {
-      ui.notifications.warn("DISCWORLD.chat.warning.gmOnly", {
-        localize: true,
-      });
+      ui.notifications.warn("DISCWORLD.chat.warning.gmOnly", { localize: true });
       return;
     }
-
     const messageData = DiscworldChatLog.getClickedMessageData(event, target);
     DWNarrativiumRoll.createNarrativiumRoll(messageData);
   }
@@ -121,14 +73,16 @@ export default class DiscworldChatLog extends foundry.applications.sidebar.tabs.
   /* -------------------------------------------------- */
 
   /**
-   * Retrieve message data from a clicked chat message element,
-   * accounting for the current generation of Foundry.
-   *
-   * @param {Event} event - The originating click event.
-   * @param {HTMLElement} target - The target element of the event.
-   * @returns {Object} An object containing the chat message and reroll status.
-   * @returns {ChatMessage} return.message - The clicked chat message.
-   * @returns {boolean} return.reroll - Whether the message was marked as a reroll.
+   * @typedef ClickedMessageData
+   * @property {ChatMessage} message    The clicked chat message.
+   * @property {boolean} reroll         Whether the message was marked as a reroll.
+   */
+
+  /**
+   * Retrieve message data from a clicked chat message element.
+   * @param {PointerEvent} event    The originating click event.
+   * @param {HTMLElement} target    The element that defined the [data-action].
+   * @returns {ClickedMessageData}
    */
   static getClickedMessageData(event, target) {
     const messageElem = target.closest(".message");

--- a/modules/datamodels/character-schema.mjs
+++ b/modules/datamodels/character-schema.mjs
@@ -1,24 +1,13 @@
-const { HTMLField, NumberField, SchemaField, StringField } =
-  foundry.data.fields;
+const { HTMLField, NumberField, SchemaField, StringField } = foundry.data.fields;
 
 export default class CharacterDataModel extends foundry.abstract.TypeDataModel {
   /** @inheritdoc */
   static defineSchema() {
     return {
-      description: new HTMLField({ required: true }),
+      description: new HTMLField(),
       luck: new SchemaField({
-        max: new NumberField({
-          nullable: false,
-          positive: true,
-          integer: true,
-          initial: 4,
-        }),
-        value: new NumberField({
-          nullable: false,
-          integer: true,
-          min: 0,
-          initial: 4,
-        }),
+        max: new NumberField({ nullable: false, positive: true, integer: true, initial: 4 }),
+        value: new NumberField({ nullable: false, integer: true, min: 0, initial: 4 }),
       }),
       pronouns: new StringField({ required: true }),
     };

--- a/modules/datamodels/trait-schema.mjs
+++ b/modules/datamodels/trait-schema.mjs
@@ -6,17 +6,9 @@ export default class TraitDataModel extends foundry.abstract.TypeDataModel {
   /** @inheritdoc */
   static defineSchema() {
     return {
-      type: new StringField({
-        required: true,
-        choices: DISCWORLD.traitTypes,
-        initial: "consequences",
-      }),
-      severity: new StringField({
-        required: true,
-        initial: "minor",
-        choices: DISCWORLD.consequenceSeverity,
-      }),
-      notes: new HTMLField({ required: true }),
+      notes: new HTMLField(),
+      severity: new StringField({ required: true, initial: "minor", choices: DISCWORLD.consequenceSeverity }),
+      type: new StringField({ required: true, choices: DISCWORLD.traitTypes, initial: "consequences" }),
     };
   }
 

--- a/modules/documents/character.mjs
+++ b/modules/documents/character.mjs
@@ -2,13 +2,13 @@ import DISCWORLD from "../config.mjs";
 import DWHelpRoll from "../rolls/help-roll.mjs";
 import DWTraitRoll from "../rolls/trait-roll.mjs";
 
-export default class DiscworldCharacter extends Actor {
+export default class DiscworldCharacter extends foundry.documents.Actor {
   /**
-   * @typedef {Object} HelpMode
-   * @prop {boolean} enabled - Whether help mode is enabled.
-   * @prop {Object} promise - The promise that resolves to the selected trait.
-   * @prop {Function|null} promise.resolve - The function to resolve the promise.
-   * @prop {Function|null} promise.reject - The function to reject the promise.
+   * @typedef HelpMode
+   * @property {boolean} enabled                  Whether help mode is enabled.
+   * @property {object} promise                   The promise that resolves to the selected trait.
+   * @property {Function|null} promise.resolve    The function to resolve the promise.
+   * @property {Function|null} promise.reject     The function to reject the promise.
    */
 
   /** @type {HelpMode} */
@@ -23,46 +23,47 @@ export default class DiscworldCharacter extends Actor {
   /* -------------------------------------------------- */
 
   /** @inheritdoc */
-  static async create(data, options = {}) {
-    data.prototypeToken = foundry.utils.mergeObject(
+  async _preCreate(data, options, user) {
+    if ((await super._preCreate(data, options, user)) === false) return false;
+    const update = foundry.utils.mergeObject(
       {
         actorLink: true,
         disposition: CONST.TOKEN_DISPOSITIONS.FRIENDLY,
-        "bar1.attribute": "luck",
+        bar1: { attribute: "luck" },
       },
       data.prototypeToken ?? {},
+      { insertKeys: false, insertValues: false, overwrite: true },
     );
-
-    return super.create(data, options);
+    this.updateSource({ prototypeToken: update });
   }
 
   /* -------------------------------------------------- */
 
   /**
-   * In Discworld, everything is a trait.
-   * So, you can pass anything that has a `name`
-   * property to `rolLTrait`.
-   *
-   * @typedef {object} TraitLike
+   * In Discworld, everything is a trait. So, you can pass anything that has a `name` property to `rollTrait`.
+   * @typedef TraitLike
    * @prop {string} name
    */
+
+  /* -------------------------------------------------- */
 
   /**
    * Handles the logic for rolling a trait from the character sheet.
    * If help mode is enabled, the trait is passed to the help promise.
    * Otherwise, a dialog is shown asking the user to select a die to roll.
-   *
-   * @param {Item|TraitLike} trait - The trait to be rolled.
+   * @param {Item|TraitLike} trait    The trait to be rolled.
+   * @param {object} [options]
+   * @param {string} [options.parentWindow]   The id of a parent window in which to render the prompt.
    * @returns {Promise<DiscworldMessage|null>}
    */
-  async rollTrait(trait) {
+  async rollTrait(trait, options = {}) {
     // A help roll will handle its own dialog/roll.
     if (this.helpMode.enabled) {
       this.helpMode.promise.resolve(trait);
       return null;
     }
 
-    const dialogResult = await this.rollTraitDialog(trait);
+    const dialogResult = await this.rollTraitDialog(trait, options);
     if (!dialogResult) return null;
 
     return DWTraitRoll.createBaseRoll(dialogResult, { actor: this, trait });
@@ -72,11 +73,13 @@ export default class DiscworldCharacter extends Actor {
 
   /**
    * Displays a dialog to prompt the user to select a die to roll.
-   *
-   * @param {Item} trait - The trait to be rolled.
-   * @returns {Promise<"d4"|"d6"|"d10"|"d12"|null>} - A promise that resolves to the selected die, or null if the dialog is cancelled.
+   * @param {Item} trait                              The trait to be rolled.
+   * @param {object} [options]
+   * @param {string} [options.parentWindow]           The id of a parent window in which to render the prompt.
+   * @returns {Promise<"d4"|"d6"|"d10"|"d12"|null>}   A promise that resolves to the selected die,
+   *                                                  or null if the dialog is cancelled.
    */
-  async rollTraitDialog(trait) {
+  async rollTraitDialog(trait, options) {
     const { Dialog } = foundry.applications.api;
     const content = await foundry.applications.handlebars.renderTemplate(
       `systems/${DISCWORLD.id}/templates/mixins/trait-quote.hbs`,
@@ -89,11 +92,18 @@ export default class DiscworldCharacter extends Actor {
     });
 
     return Dialog.wait({
-      classes: ["discworld"],
-      position: { width: 400, height: "auto" },
-      window: { title: "DISCWORLD.dialog.rollTrait.title" },
-      content,
       buttons,
+      content,
+      classes: ["discworld"],
+      position: { width: 400 },
+      window: {
+        title: "DISCWORLD.dialog.rollTrait.title",
+      },
+      renderOptions: {
+        window: {
+          windowId: options.parentWindow,
+        },
+      },
     });
   }
 
@@ -101,7 +111,6 @@ export default class DiscworldCharacter extends Actor {
 
   /**
    * Enable help mode and render the character sheet, which awaits a trait roll.
-   *
    * @param {DiscworldMessage} message    The message that triggered help mode.
    * @returns {Promise<DiscworldMessage|null>}
    */
@@ -128,9 +137,7 @@ export default class DiscworldCharacter extends Actor {
     }
 
     // Deduct a luck point (we've already determined the character has at least one).
-    this.update({
-      "system.luck.value": this.system.luck.value - 1,
-    });
+    this.update({ "system.luck.value": this.system.luck.value - 1 });
 
     // Close the sheet if it wasn't already opened.
     if (close) this.sheet.close();
@@ -140,9 +147,9 @@ export default class DiscworldCharacter extends Actor {
 
     // Create the help roll and send to chat.
     return DWHelpRoll.createHelpRoll({
-      term: dialogResult,
-      trait,
       message,
+      trait,
+      term: dialogResult,
     });
   }
 
@@ -151,9 +158,8 @@ export default class DiscworldCharacter extends Actor {
   /**
    * Returns a promise that resolves to the trait selected while in help mode.
    * Resolves to null if help mode is cancelled.
-   *
-   * @returns {Promise<Item|null>} A promise that resolves to the selected
-   *                               trait, or null if help mode is cancelled.
+   * @returns {Promise<Item|null>}    A promise that resolves to the selected
+   *                                  trait, or null if help mode is cancelled.
    */
   waitForTraitSelection() {
     return new Promise((resolve) => {
@@ -166,7 +172,9 @@ export default class DiscworldCharacter extends Actor {
 
   /* -------------------------------------------------- */
 
-  /** Leave help mode and re-render the character sheet, if open. */
+  /**
+   * Leave help mode and re-render the character sheet, if open.
+   */
   leaveHelpMode() {
     this.resetHelpMode();
     this.sheet.render();
@@ -176,11 +184,8 @@ export default class DiscworldCharacter extends Actor {
 
   /**
    * Resets the help mode flag and rejects any pending help promises.
-   *
-   * This is called when the character sheet is closed, or when the help mode
-   * flag is explicitly toggled off.
-   *
-   * @returns {void}
+   * This is called when the character sheet is closed,
+   * or when the help mode flag is explicitly toggled off.
    */
   resetHelpMode() {
     this.helpMode.enabled = false;

--- a/modules/rolls/help-roll.mjs
+++ b/modules/rolls/help-roll.mjs
@@ -1,17 +1,13 @@
 import DWTraitRoll from "./trait-roll.mjs";
 
-/**
- * @extends Roll
- */
 export default class DWHelpRoll extends DWTraitRoll {
   /**
    * Create a help roll, and update the parent message with the result.
-   *
    * @param {object} options
-   * @param {DiceTermOptions} options.term - The term to be rolled.
-   * @param {Item} options.trait - The trait associated with this roll.
-   * @param {DiscworldMessage} options.message - The chat message to update.
-   * @returns {Promise<DiscworldMessage>} A promise that resolves to the updated chat message.
+   * @param {DiceTermOptions} options.term        The term to be rolled.
+   * @param {Item} options.trait                  The trait associated with this roll.
+   * @param {DiscworldMessage} options.message    The chat message to update.
+   * @returns {Promise<DiscworldMessage>}         A promise that resolves to the updated chat message.
    */
   static async createHelpRoll({ term, trait, message }) {
     const { actor } = trait;

--- a/modules/rolls/narrativium-roll.mjs
+++ b/modules/rolls/narrativium-roll.mjs
@@ -1,15 +1,10 @@
-/**
- * @extends Roll
- */
-export default class DWNarrativiumRoll extends Roll {
+export default class DWNarrativiumRoll extends foundry.dice.Roll {
   /**
-   * Create a Narrativium (GM) roll, and update the parent message
-   * with the result.
-   *
+   * Create a Narrativium (GM) roll, and update the parent message with the result.
    * @param {object} options
-   * @param {DiscworldMessage} options.message - The chat message to update.
-   * @param {boolean} [options.reroll=false] - Whether this is a reroll.
-   * @returns {Promise<DiscworldMessage|null>} A promise that resolves to the updated chat message.
+   * @param {DiscworldMessage} options.message    The chat message to update.
+   * @param {boolean} [options.reroll=false]      Whether this is a reroll.
+   * @returns {Promise<DiscworldMessage|null>}    A promise that resolves to the updated chat message.
    */
   static async createNarrativiumRoll({ message, reroll = false }) {
     // Determine the type of narrativium roll (regular or reroll).

--- a/modules/rolls/trait-roll.mjs
+++ b/modules/rolls/trait-roll.mjs
@@ -1,22 +1,26 @@
 import DISCWORLD from "../config.mjs";
 
-/**
- * @extends Roll
- */
-export default class DWTraitRoll extends Roll {
+export default class DWTraitRoll extends foundry.dice.Roll {
   /**
    * @typedef {"d4"|"d6"|"d10"|"d12"} DiceTermOptions
    */
+
+  /* -------------------------------------------------- */
+
   /**
    * Creates a new DiscworldRoll instance.
-   *
-   * @param {DiceTermOptions} formula - The dice formula to evaluate.
-   * @param {object} data - An object the roll uses to evaluate (see Foundry docs).
-   * @param {object} options - An object with additional options.
-   * @param {DiscworldCharacter} options.actor - The Actor being rolled for.
-   * @param {Item} options.trait - The Item being rolled.
+   * @param {DiceTermOptions} formula               The dice formula to evaluate.
+   * @param {object} data                           An object the roll uses to evaluate (see Foundry docs).
+   * @param {object} [options]                      An object with additional options.
+   * @param {DiscworldCharacter} [options.actor]    The Actor being rolled for.
+   * @param {Item} [options.trait]                  The Item being rolled.
    */
   constructor(formula, data, options = {}) {
+    options = {
+      ...options,
+      actor: options.actor instanceof foundry.documents.Actor ? options.actor.uuid : null,
+      trait: options.item instanceof foundry.documents.Item ? options.trait.uuid : null,
+    };
     super(formula, data, options);
   }
 
@@ -36,21 +40,32 @@ export default class DWTraitRoll extends Roll {
 
   /* -------------------------------------------------- */
 
-  /** @type {DiscworldCharacter} The Actor that initiated the roll. */
+  /**
+   * The Actor that initiated the roll.
+   * @type {DiscworldCharacter|null}
+   */
   get actor() {
-    return this.options.actor;
+    const actor = fromUuidSync(this.options.actor);
+    return (actor instanceof foundry.documents.Actor) ? actor : null;
   }
 
   /* -------------------------------------------------- */
 
-  /** @type {Item} The Trait used for this roll. */
+  /**
+   * The trait used for this roll.
+   * @type {Item|null}
+   */
   get trait() {
-    return this.options.trait;
+    const item = fromUuidSync(this.options.trait);
+    return (item instanceof foundry.documents.Item) ? item : null;
   }
 
   /* -------------------------------------------------- */
 
-  /** @type {DiceTermOptions} The dice term used for this roll. */
+  /**
+   * The dice term used for this roll.
+   * @type {DiceTermOptions}
+   */
   get term() {
     return this.dice[0].denomination;
   }
@@ -59,20 +74,17 @@ export default class DWTraitRoll extends Roll {
 
   /**
    * Create a base Trait roll and send to chat.
-   *
-   * @param {DiceTermOptions} formula - The roll formula.
-   * @param {object} [options] - The options to pass to the `DiscworldRoll` constructor.
-   *                             See `constructor` above and the Foundry API.
-   * @returns {Promise<DiscworldMessage>} A promise that resolves to the chat message.
+   * @param {DiceTermOptions} formula       The roll formula.
+   * @param {object} [options]              The options to pass to the `DiscworldRoll` constructor.
+   *                                        See `constructor` above and the Foundry API.
+   * @returns {Promise<DiscworldMessage>}   A promise that resolves to the chat message.
    */
   static async createBaseRoll(formula, options) {
     const rollData = options.actor?.getRollData() ?? {};
     const roll = new DWTraitRoll(formula, rollData, options);
 
     return roll.toMessage({
-      speaker: getDocumentClass("ChatMessage").getSpeaker({
-        actor: options.actor,
-      }),
+      speaker: getDocumentClass("ChatMessage").getSpeaker({ actor: options.actor }),
     });
   }
 }

--- a/modules/sheets/base-document-sheet.mjs
+++ b/modules/sheets/base-document-sheet.mjs
@@ -41,7 +41,6 @@ const DiscworldSheetMixin = (Base) => {
 
     /**
      * Determines if the sheet is currently in edit mode.
-     *
      * @type {boolean} True if the sheet is in edit mode, false otherwise.
      */
     get isEditMode() {
@@ -96,11 +95,9 @@ const DiscworldSheetMixin = (Base) => {
     /* -------------------------------------------------- */
 
     /**
-     * Wraps all buttons in the window header inside a div,
-     * allowing them to be positioned as a group within
-     * the decoration border.
-     *
-     * @param {HTMLElement} element The Sheet element.
+     * Wraps all buttons in the window header inside a div, allowing them
+     * to be positioned as a group within the decoration border.
+     * @param {HTMLElement} element The sheet element.
      */
     static _encapsulateHeaderButtons(element) {
       if (element.querySelector(".button-wrapper")) return;
@@ -125,8 +122,7 @@ const DiscworldSheetMixin = (Base) => {
 
     /**
      * Creates and injects a the sheet frame decoration.
-     *
-     * @param {HTMLElement} element The Sheet element.
+     * @param {HTMLElement} element The sheet element.
      */
     static _injectFrameDecoration(element) {
       const decorationContainer = createElement("div", {
@@ -146,16 +142,15 @@ const DiscworldSheetMixin = (Base) => {
       windowContent.insertBefore(decorationContainer, windowContent.firstChild);
     }
 
-    /* -------------- COMMON SHEET HANDLERS ------------- */
+    /* -------------------------------------------------- */
+    /*   Common Sheet Handlers                            */
+    /* -------------------------------------------------- */
 
     /**
      * Handle toggling the sheet between edit and play modes.
-     *
      * Not private because this is called outside the class.
-     *
-     * @param {Event} event
-     * @param {HTMLElement} target
-     * @returns
+     * @param {PointerEvent} event    The originating click event.
+     * @param {HTMLElement} target    The element that defined the [data-action].
      */
     static onToggleSheetMode(event, target) {
       if (!this.isEditable) return; // Permissions, not our own internal edit mode.

--- a/modules/sheets/character-sheet.mjs
+++ b/modules/sheets/character-sheet.mjs
@@ -56,9 +56,7 @@ export default class CharacterSheet extends DiscworldSheetMixin(ActorSheetV2) {
 
   /**
    * Helper to check if the actor is currently in help mode.
-   *
    * @type {boolean}
-   * @readonly
    */
   get isHelpMode() {
     return this.actor.helpMode.enabled;
@@ -76,14 +74,10 @@ export default class CharacterSheet extends DiscworldSheetMixin(ActorSheetV2) {
     context.fields = this._getFields();
 
     // Enrich the description field.
-    context.fields.description.enriched =
-      await foundry.applications.ux.TextEditor.implementation.enrichHTML(
-        context.fields.description.value,
-        {
-          rollData: this.document.getRollData(),
-          relativeTo: this.document,
-        },
-      );
+    context.fields.description.enriched = await CONFIG.ux.TextEditor.enrichHTML(
+      context.fields.description.value,
+      { rollData: this.document.getRollData(), relativeTo: this.document },
+    );
 
     // Construct arrays of traits, filtered by category.
     context.traitGroups = this._getTraitGroups();
@@ -96,21 +90,9 @@ export default class CharacterSheet extends DiscworldSheetMixin(ActorSheetV2) {
 
   /* -------------------------------------------------- */
 
-  /** @inheritdoc */
-  async _preparePartContext(partId, context, options) {
-    // By default, this returns the same mutated context.
-    context = await super._preparePartContext(partId, context, options);
-
-    context.tab = context.tabs[partId];
-
-    return context;
-  }
-
-  /* -------------------------------------------------- */
-
   /**
    * Create context for input fields.
-   * @returns {object} Organized context for fields.
+   * @returns {object}    Organized context for fields.
    */
   _getFields() {
     const { document } = this;
@@ -136,7 +118,6 @@ export default class CharacterSheet extends DiscworldSheetMixin(ActorSheetV2) {
       },
       pronouns: {
         field: system.schema.getField("pronouns"),
-        placeholder: game.i18n.localize("DISCWORLD.character.pronouns"),
         value: this.isEditMode ? system._source.pronouns : system.pronouns,
       },
     };
@@ -149,14 +130,11 @@ export default class CharacterSheet extends DiscworldSheetMixin(ActorSheetV2) {
    * @returns {Record<keyof DISCWORLD.traitTypes, Item[]>}
    */
   _getTraitGroups() {
-    const traitGroups = {};
-    for (const traitType of Object.keys(DISCWORLD.traitTypes)) {
-      traitGroups[traitType] = this.actor.items.filter(
-        (item) => item.system.type === traitType,
-      );
-    }
-
-    return traitGroups;
+    const items = Object.groupBy(this.actor.items, item => item.system.type);
+    return Object.keys(DISCWORLD.traitTypes).reduce((acc, traitType) => {
+      acc[traitType] = items[traitType] ?? [];
+      return acc;
+    }, {});
   }
 
   /* -------------------------------------------------- */
@@ -220,34 +198,39 @@ export default class CharacterSheet extends DiscworldSheetMixin(ActorSheetV2) {
    * @returns {object[]}    Context options.
    */
   #prepareTraitContextOptions() {
-    const getItem = (li) => this.document.items.get(li.dataset.itemId);
+    const getItem = (target) => this.document.items.get(target.dataset.itemId);
     return [
       {
-        name: "DISCWORLD.sheet.context.actor.trait.use",
-        icon: "<i class='fa-solid fa-fw fa-hand-fist'></i>",
-        condition: () => this.document.isOwner,
-        callback: (li) => this.document.rollTrait(getItem(li)),
+        label: "DISCWORLD.sheet.context.actor.trait.use",
+        icon: "fa-solid fa-hand-fist",
+        visible: () => this.document.isOwner,
+        onClick: (event, target) => this.document.rollTrait(
+          getItem(target),
+          { parentWindow: this.window.windowId },
+        ),
       },
       {
-        name: "DISCWORLD.sheet.context.actor.trait.edit",
-        icon: "<i class='fa-solid fa-fw fa-edit'></i>",
-        condition: () => this.document.isOwner,
-        callback: (li) => getItem(li).sheet.render({ force: true }),
+        label: "DISCWORLD.sheet.context.actor.trait.edit",
+        icon: "fa-solid fa-edit",
+        visible: () => this.document.isOwner,
+        onClick: (event, target) => getItem(target).sheet.render({ force: true }),
       },
       {
-        name: "DISCWORLD.sheet.context.actor.trait.delete",
-        icon: "<i class='fa-solid fa-fw fa-trash'></i>",
-        condition: () => this.document.isOwner,
-        callback: (li) => getItem(li).deleteDialog(),
+        label: "DISCWORLD.sheet.context.actor.trait.delete",
+        icon: "fa-solid fa-trash",
+        visible: () => this.document.isOwner,
+        onClick: (event, target) => getItem(target).deleteDialog({
+          renderOptions: { window: { windowId: this.window.windowId } },
+        }),
       },
       {
-        name: "DISCWORLD.sheet.context.actor.trait.duplicate",
-        icon: "<i class='fa-solid fa-fw fa-copy'></i>",
-        condition: () => this.document.isOwner,
-        callback: (li) => {
-          const item = getItem(li);
+        label: "DISCWORLD.sheet.context.actor.trait.duplicate",
+        icon: "fa-solid fa-copy",
+        visible: () => this.document.isOwner,
+        onClick: (event, target) => {
+          const item = getItem(target);
           item.clone(
-            { name: game.i18n.format("DOCUMENT.CopyOf", { name: item.name }) },
+            { name: _loc("DOCUMENT.CopyOf", { name: item.name }) },
             { save: true, renderSheet: true },
           );
         },
@@ -269,8 +252,8 @@ export default class CharacterSheet extends DiscworldSheetMixin(ActorSheetV2) {
   /* -------------------------------------------------- */
 
   /**
-   * Leave help mode and re-render the character sheet,
-   * if open.
+   * Leave help mode and re-render the character sheet, if open.
+   * @this CharacterSheet
    */
   static #leaveHelpMode() {
     this.actor.leaveHelpMode();
@@ -280,10 +263,9 @@ export default class CharacterSheet extends DiscworldSheetMixin(ActorSheetV2) {
 
   /**
    * Handle clicks on trait actions (add, edit, delete, roll).
-   *
-   * @param {Event} event - The originating click event.
-   * @param {HTMLElement} target - The target element of the event.
-   * @returns {void}
+   * @this CharacterSheet
+   * @param {PointerEvent} event    The originating click event.
+   * @param {HTMLElement} target    The element that defined the [data-action].
    */
   static #traitAction(event, target) {
     const { actionType, itemId } = target.dataset;
@@ -311,21 +293,17 @@ export default class CharacterSheet extends DiscworldSheetMixin(ActorSheetV2) {
 
   /**
    * Add a new trait of the given type to the character.
-   *
-   * @param {string} traitType - The type of trait to add. Must be one of the
-   *                             {@link DISCWORLD.traitTypes} constants.
-   * @returns {Promise<void>}
+   * @this CharacterSheet
+   * @param {string} traitType    The type of trait to add. Must be one of the {@link DISCWORLD.traitTypes} constants.
    */
   static async #addTrait(traitType) {
     const newTrait = await getDocumentClass("Item").create(
       {
+        name: _loc("DOCUMENT.New", { type: _loc(`DISCWORLD.trait.type.${traitType}`) }),
         type: "trait",
-        name: game.i18n.format("DOCUMENT.New", {
-          type: game.i18n.localize(`DISCWORLD.trait.type.${traitType}`),
-        }),
         system: { type: traitType },
       },
-      { parent: this.document, renderSheet: true },
+      { parent: this.document, renderSheet: false },
     );
 
     newTrait.sheet.render({ force: true, autofocus: true });
@@ -335,9 +313,8 @@ export default class CharacterSheet extends DiscworldSheetMixin(ActorSheetV2) {
 
   /**
    * Opens the Trait sheet for editing with autofocus enabled on the name field.
-   *
-   * @param {Item} trait - The trait item to be edited.
-   * @returns {Promise<void>}
+   * @this CharacterSheet
+   * @param {Item} trait    The trait item to be edited.
    */
   static async #editTrait(trait) {
     trait.sheet.render({ force: true, autofocus: true });
@@ -347,14 +324,11 @@ export default class CharacterSheet extends DiscworldSheetMixin(ActorSheetV2) {
 
   /**
    * Prompts the user for confirmation before deleting a Trait.
-   *
-   * @param {Item} trait - The trait item to be deleted.
-   * @returns {Promise<void>}
+   * @this CharacterSheet
+   * @param {Item} trait    The trait item to be deleted.
    */
   static async #deleteTrait(trait) {
-    const content = game.i18n.format("DISCWORLD.dialog.deleteTrait.content", {
-      traitName: trait.name,
-    });
+    const content = _loc("DISCWORLD.dialog.deleteTrait.content", { traitName: trait.name });
     trait.deleteDialog({ content: `<p>${content}</p>` });
   }
 
@@ -362,19 +336,16 @@ export default class CharacterSheet extends DiscworldSheetMixin(ActorSheetV2) {
 
   /**
    * Prompts the user to select a die to roll and then rolls the trait.
-   *
-   * @param {Item} trait - The trait to be rolled.
-   * @returns {Promise<void>}
+   * @this CharacterSheet
+   * @param {Item} trait    The trait to be rolled.
    */
   static async #rollTrait(trait) {
-    const { actor } = this;
-    actor.rollTrait(trait);
+    this.actor.rollTrait(trait, { parentWindow: this.window.windowId });
   }
 
   /**
    * Rolls the character's name/pronouns as a trait.
-   *
-   * @returns {Promise<void>}
+   * @this CharacterSheet
    */
   static #rollNameAsTrait() {
     const { actor } = this;
@@ -388,20 +359,19 @@ export default class CharacterSheet extends DiscworldSheetMixin(ActorSheetV2) {
     actor.rollTrait({ actor, name: traitText });
   }
 
+  /* -------------------------------------------------- */
+
   /**
    * Rolls a part of the character's description as a trait (TraitLike).
-   *
-   * @param {string} html - The html of the TraitLike to be rolled.
-   *                        @see DiscworldCharacter.rollTrait
-   * @returns {Promise<void>}
+   * @this CharacterSheet
+   * @param {string} html   The html of the TraitLike to be rolled.
+   * @see DiscworldCharacter.rollTrait
    */
   static async #rollDescriptionAsTrait(html) {
     const { actor } = this;
-    const enrichedText =
-      await foundry.applications.ux.TextEditor.implementation.enrichHTML(html, {
-        rollData: actor.getRollData(),
-        relativeTo: actor,
-      });
+    const enrichedText = await CONFIG.ux.TextEditor.enrichHTML(html, {
+      rollData: actor.getRollData(), relativeTo: actor,
+    });
     actor.rollTrait({ actor, name: enrichedText });
   }
 }

--- a/modules/sheets/trait-sheet.mjs
+++ b/modules/sheets/trait-sheet.mjs
@@ -3,9 +3,6 @@ import DiscworldSheetMixin from "./base-document-sheet.mjs";
 
 const { ItemSheetV2 } = foundry.applications.sheets;
 
-/**
- * @extends ItemSheetV2
- */
 export default class TraitSheet extends DiscworldSheetMixin(ItemSheetV2) {
   /** @inheritdoc */
   static DEFAULT_OPTIONS = {
@@ -63,39 +60,29 @@ export default class TraitSheet extends DiscworldSheetMixin(ItemSheetV2) {
     };
 
     context.fields.severity.show = context.fields.type.value === "consequences";
-    context.fields.notes.enriched =
-      await foundry.applications.ux.TextEditor.implementation.enrichHTML(
-        context.fields.notes.value,
-        {
-          rollData: this.document.getRollData(),
-          relativeTo: this.document,
-        },
-      );
+    context.fields.notes.enriched = await CONFIG.ux.TextEditor.enrichHTML(
+      context.fields.notes.value,
+      { rollData: this.document.getRollData(), relativeTo: this.document },
+    );
 
     return context;
   }
 
   /* -------------------------------------------------- */
 
-  /**
-   * A user is most likely going to be editing the name field
-   * when opening the trait sheet from a character sheet.
-   * So, we override this method to add a new option to autofocus
-   * that field.
-   *
-   * @inheritdoc
-   * @param {Object} options
-   * @param {boolean} options.autofocus - Whether to autofocus the name field
-   * @returns {Promise<ApplicationV2>} - See Foundry API docs.
-   */
+  /** @inheritdoc */
   async render(options) {
     const renderedApp = await super.render(options);
     const { autofocus } = options;
 
+    // A user is most likely going to be editing the name field when opening the trait
+    // sheet from a character sheet. So, we override this method to add a new option
+    // to autofocus that field.
+
     if (autofocus) {
       const nameField = this.element.querySelector("input[name='name']");
-      nameField.focus();
-      nameField.select();
+      nameField?.focus();
+      nameField?.select();
     }
 
     return renderedApp;

--- a/modules/utils/_module.mjs
+++ b/modules/utils/_module.mjs
@@ -1,3 +1,3 @@
+export { default as createElement } from "./dom-manipulation.mjs";
 export { default as parseInputDelta } from "./parse-input-delta.mjs";
 export { default as transitionClass } from "./animations.mjs";
-export { default as createElement } from "./dom-manipulation.mjs";

--- a/modules/utils/animations.mjs
+++ b/modules/utils/animations.mjs
@@ -1,27 +1,26 @@
 /**
- * @typedef {object} ClassesToRemove
- * @property {string[]} remove - An array of class names to be removed from the element.
- */
-/**
- * @typedef {object} ClassesToAdd
- * @property {string[]} add - An array of class names to be added to the element.
- */
-/**
- * @typedef {ClassesToRemove | ClassesToAdd} TransitionOptions
- * A TransitionOptions object must have at least one of `remove` or `add` defined.
+ * @typedef ClassesToRemove
+ * @property {string[]} remove    An array of class names to be removed from the element.
  */
 
 /**
- * Avoid callback hell by wrapping `transitionend` event in a Promise,
- * allowing chaining of transitions with cleaner code.
- *
- * Adds specified class names to trigger transition.
- *
- * @param {HTMLElement} element - The DOM element to which class names will be added.
- * @param {TransitionOptions} options - An object with `remove` and/or `add` properties.
- * @param {number} [timeout=1000] - Optional timeout in milliseconds (default: 1000ms)
- * @returns {Promise<HTMLElement>} A promise that resolves with the element
- *                                 once the CSS transition has ended or timed out.
+ * @typedef ClassesToAdd
+ * @property {string[]} add   An array of class names to be added to the element.
+ */
+
+/**
+ * A TransitionOptions object must have at least one of `remove` or `add` defined.
+ * @typedef {ClassesToRemove | ClassesToAdd} TransitionOptions
+ */
+
+/**
+ * Avoid callback hell by wrapping `transitionend` event in a Promise, allowing chaining
+ * of transitions with cleaner code. Adds specified class names to trigger transition. *
+ * @param {HTMLElement} element         The DOM element to which class names will be added.
+ * @param {TransitionOptions} options   An object with `remove` and/or `add` properties.
+ * @param {number} [timeout=1000]       Optional timeout in milliseconds (default: 1000ms)
+ * @returns {Promise<HTMLElement>}      A promise that resolves with the element
+ *                                      once the CSS transition has ended or timed out.
  */
 export default function transitionClass(element, { remove = [], add = [] }, timeout = 1000) {
   const { promise, resolve } = Promise.withResolvers();

--- a/modules/utils/dom-manipulation.mjs
+++ b/modules/utils/dom-manipulation.mjs
@@ -2,17 +2,13 @@
  * A helper function to create an HTML element and add various properties to it.
  * Right now it just creates an element and adds classes, but it could be
  * extended to add other properties as well, as needed.
- *
- * @param {string} tagName - The name of the element to create (e.g. 'div')
+ * @param {string} tagName                The name of the element to create (e.g. 'div').
  * @param {object} [options]
- * @param {string[]} [options.classes] - An array of class names to add to the element
- * @returns
+ * @param {string[]} [options.classes]    An array of class names to add to the element.
+ * @returns {HTMLElement}                 The created element.
  */
-function createElement(tagName, { classes = [] } = {}) {
+export default function createElement(tagName, { classes = [] } = {}) {
   const element = document.createElement(tagName);
   element.classList.add(...classes);
-
   return element;
 }
-
-export default createElement;

--- a/modules/utils/handlebars.mjs
+++ b/modules/utils/handlebars.mjs
@@ -16,6 +16,9 @@ export default async function preloadTemplates() {
 
 /* -------------------------------------------------- */
 
+/**
+ * Register system-specific handlebars helpers.
+ */
 export function registerHelpers() {
   /**
    * Returns the path to a system file
@@ -24,90 +27,4 @@ export function registerHelpers() {
     "systemFilePath",
     (string) => `systems/${DISCWORLD.id}/${string}`,
   );
-
-  /**
-   * Compares two values with the given operator. If no operator is provided,
-   * '===' is used by default.
-   *
-   * @see http://doginthehat.com.au/2012/02/comparison-block-helper-for-handlebars-templates/#comment-44
-   * @param {*} lValue
-   * @param {string} operator
-   * @param {*} rValue
-   */
-  Handlebars.registerHelper("compare", function (...args) {
-    if (args.length < 3) {
-      throw new Error("Handlerbars Helper 'compare' needs 2 parameters");
-    }
-
-    let [lValue, operator, rValue, options] = args;
-
-    if (options === undefined) {
-      options = rValue;
-      rValue = operator;
-      operator = "===";
-    }
-
-    const operators = {
-      "===": (l, r) => {
-        return l === r;
-      },
-      "!==": (l, r) => {
-        return l !== r;
-      },
-      "<": (l, r) => {
-        return l < r;
-      },
-      ">": (l, r) => {
-        return l > r;
-      },
-      "<=": (l, r) => {
-        return l <= r;
-      },
-      ">=": (l, r) => {
-        return l >= r;
-      },
-      typeof(l, r) {
-        return typeof l === r;
-      },
-      "&&": (l, r) => {
-        return !!l && !!r;
-      },
-      "||": (l, r) => {
-        return !!l || !!r;
-      },
-    };
-
-    if (!operators[operator]) {
-      throw new Error(
-        `Handlerbars Helper 'compare' doesn't know the operator ${operator}`,
-      );
-    }
-
-    const result = operators[operator](lValue, rValue);
-
-    if (result) {
-      return options.fn(this);
-    }
-    return options.inverse(this);
-  });
-
-  /* ----------------- CONFIG HELPERS ----------------- */
-
-  // Return the keys for a config object.
-  Handlebars.registerHelper("getConfigKeys", (path) => {
-    const obj = foundry.utils.getProperty(DISCWORLD, path);
-    return Object.keys(obj);
-  });
-
-  // Return the values for a config object.
-  Handlebars.registerHelper("getConfigValues", (path) => {
-    const obj = foundry.utils.getProperty(DISCWORLD, path);
-    return Object.values(obj);
-  });
-
-  // Return a config object.
-  Handlebars.registerHelper("getConfigObject", (path) => {
-    const obj = foundry.utils.getProperty(DISCWORLD, path);
-    return obj;
-  });
 }

--- a/modules/utils/keybindings.mjs
+++ b/modules/utils/keybindings.mjs
@@ -1,18 +1,19 @@
 import DISCWORLD from "../config.mjs";
 
 export default function registerKeybindings() {
+  // TODO: This keybinding does not work in detached windows.
   game.keybindings.register(DISCWORLD.id, "toggleEditMode", {
     name: "Toggle Edit Mode",
     hint: "Turn character sheet 'edit mode' on and off.",
     editable: [
-      {
-        key: "KeyE",
-      },
+      { key: "KeyE" },
     ],
-    onDown: () => {
-      const { activeWindow } = ui;
-      if (!activeWindow?.rendered) return;
-      activeWindow.constructor.onToggleSheetMode.call(activeWindow);
+    onDown: (event) => {
+      const application = ui.activeWindow || game.user.character?.sheet;
+      if (!application.rendered || (typeof application.constructor.onToggleSheetMode !== "function")) {
+        return;
+      }
+      application.constructor.onToggleSheetMode.call(application);
     },
     precedence: CONST.KEYBINDING_PRECEDENCE.NORMAL,
   });

--- a/system.json
+++ b/system.json
@@ -5,8 +5,8 @@
   "version": "dev",
   "license": "Apache License, Version 2.0",
   "compatibility": {
-    "minimum": "13.351",
-    "verified": "13"
+    "minimum": "14.358",
+    "verified": "14"
   },
   "authors": [
     {
@@ -54,14 +54,14 @@
   "packs": [
     {
       "name": "discworld-quickstart",
-      "label": "Quickstart",
+      "label": "DISCWORLD.PACKS.QUICKSTART",
       "system": "discworld-modiphius",
       "type": "JournalEntry",
       "path": "packs/discworld-quickstart"
     },
     {
       "name": "pre-generated-characters",
-      "label": "Pre-Generated Characters",
+      "label": "DISCWORLD.PACKS.PREGENS",
       "system": "discworld-modiphius",
       "type": "Actor",
       "path": "packs/pre-generated-characters"

--- a/templates/character-sheet/header.hbs
+++ b/templates/character-sheet/header.hbs
@@ -24,7 +24,7 @@
 
     <h1 class="document-name flexrow">
       {{#if isEditMode}}
-      {{formInput fields.name.field value=fields.name.value placeholder=fields.name.placeholder}}
+      {{formInput fields.name.field value=fields.name.value placeholder=(localize "DOCUMENT.FIELDS.name.label")}}
       {{else}}
       <span>{{document.name}}</span>
       {{/if}}
@@ -44,7 +44,7 @@
 
       <div class="detail-right pronouns">
         {{#if isEditMode}}
-        {{formInput fields.pronouns.field value=fields.pronouns.value placeholder=fields.pronouns.placeholder}}
+        {{formInput fields.pronouns.field value=fields.pronouns.value}}
         {{else}}
         {{document.system.pronouns}}
         {{/if}}


### PR DESCRIPTION
All-in-one fix for deprecations and compatibility with new core features, mainly detached windows. There wasn't much use for (or even ability to) calling `Application#renderChild` since most relevant "child" windows were constructed using `Dialog.wait`.

Changes made:
- Use `_loc` for localization.
- Support detached windows.
- Remove unused handlebars helpers.
- General code styling changes.
- Localize pack names.
- Support `placeholder` in i18n.
- Remove v12 leftover in the ChatLog.
- Remove `required: true` from HTMLFields. (This is the default.)
- Move `prototypeToken` properties from `Actor.create` into `Actor#_preCreate`.
- Fix issue with actor/trait not being stored properly in `TraitRoll`. The uuid is now stored and the actor or item is fetched in the getter.
- Removed unneeded `_preparePartContext` from character sheet. It was performing the default functions.
- Change context menu options for new v14 format; the properties are label, visible, onClick, and icon. Note that the `fa-fw` class was removed; core adds this automatically.
- Swap long form `foundry.applications.ux.TextEditor.implementation` for `CONFIG.ux.TextEditor`.
- Bumped core minimum to 14.358.